### PR TITLE
Bugfix - No more empty albums

### DIFF
--- a/yugiohbot/main.py
+++ b/yugiohbot/main.py
@@ -22,6 +22,10 @@ def function(event, context):
 
     booster_pack = create_booster_pack(reactions)
 
+    if len(booster_pack) == 0:
+        print('No images in booster pack. All done here!')
+        return None
+
     images = []
     for i, id in enumerate(booster_pack):
         try:


### PR DESCRIPTION
Empty albums are a pain and waste space/resources. This PR stops execution when no images would normally be posted.